### PR TITLE
Android Push Fix

### DIFF
--- a/src/android/ParseApplication.java
+++ b/src/android/ParseApplication.java
@@ -25,6 +25,7 @@ public class ParseApplication extends Application
 	public void onCreate() {
 		super.onCreate();
 		// register device for parse
+		Parse.enableLocalDatastore(this);
 		Parse.initialize(this, "<%=app.parse.app_id%>", "<%=app.parse.client_key%>");
 		PushService.setDefaultPushCallback(this, MainActivity.class);
 		ParseInstallation.getCurrentInstallation().saveInBackground();


### PR DESCRIPTION
Added call to enableLocalDatastore inside the application class to keep parse sessions fresh and avoid crashing when the phone tried to wake the app either on receipt of a push notification or on unlock.
